### PR TITLE
added useContext

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,17 +1,6 @@
 {
   "users": [
     {
-      "id": 1,
-      "name": "Jimmy A. User123456",
-      "dob": "03/13/2001",
-      "phone": "7277588823",
-      "email": "jimmya@invalid.email",
-      "signature": {
-        "pin": "031302",
-        "fontStyle": "Dancing Script"
-      }
-    },
-    {
       "id": 5,
       "name": "jake barbie",
       "dob": "04/19/2004",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,34 +4,33 @@ import List from "./components/ListUsers";
 import User from "./interfaces/User";
 import Toolbar from "./components/Toolbar";
 import UserInfo from "./components/UserInfo";
+import Context from "./context";
 
 function App() {
   const [userList, setUserList] = useState<User[]>([]);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
-
-  const handleUserClick = (user: User) => {
-    setSelectedUser(user);
-  };
 
   const handleCloseUserInfo = () => {
     setSelectedUser(null);
   };
 
   return (
-    <div className="app">
-      <Toolbar userList={userList} setUserList={setUserList} />
-      <div className={`list-container ${selectedUser ? 'active' : ''}`}>
-        <List userList={userList} setUserList={setUserList} selectedUser={selectedUser} onUserClick={handleUserClick} />
+    <Context.Provider value={{ userList, setUserList, selectedUser, setSelectedUser }}>
+      <div className="app">
+        <Toolbar />
+        <div className={`list-container ${selectedUser ? 'active' : ''}`}>
+          <List />
+        </div>
+        {selectedUser && (
+          <UserInfo
+            userList={userList}
+            selectedUser={selectedUser}
+            onCloseUserInfo={handleCloseUserInfo}
+            setUserList={setUserList}
+          />
+        )}
       </div>
-      {selectedUser && (
-        <UserInfo
-          userList={userList}
-          selectedUser={selectedUser}
-          onCloseUserInfo={handleCloseUserInfo}
-          setUserList={setUserList}
-        />
-      )}
-    </div>
+    </Context.Provider>
   );
 }
 

--- a/src/components/ListUsers.tsx
+++ b/src/components/ListUsers.tsx
@@ -1,12 +1,14 @@
-import React from "react";
-import ListProps from "../interfaces/ListProps";
+import React, { useContext } from "react";
 import { ReactComponent as PanelLeftClose } from "../assets/panel-left-close.svg";
+import Context from "../context";
+import User from "../interfaces/User";
 
-const List: React.FC<ListProps> = ({ userList, setUserList, selectedUser, onUserClick }) => {
+  function List() {
+    const { userList, selectedUser, onUserClick } = useContext(Context);
   return (
     <div>
       <div className="list-container">
-        {userList.map((user) => (
+        {userList.map((user: User) => (
           <div
             key={user.id}
             className={`card ${selectedUser === user ? "active" : ""}`}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import AddUser from "./AddUser";
 import User from "../interfaces/User";
-import ToolbarProps from "../interfaces/ToolbarProps";
+import Context from "../context";
 
-const Toolbar: React.FC<ToolbarProps> = ({ userList, setUserList }) => {
+function Toolbar() {
+  const { userList, setUserList } = useContext(Context);
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isSortOpen, setIsSortOpen] = useState(false);
   const [isFilterOpen, setIsFilterOpen] = useState(false);
@@ -34,7 +35,7 @@ const Toolbar: React.FC<ToolbarProps> = ({ userList, setUserList }) => {
     })
       .then((response) => response.json())
       .then((data) => {
-        setUserList((prevList) => [...prevList, data]);
+        setUserList((prevList: User[]) => [...prevList, data]);
         setIsPopupOpen(false);
       })
       .catch((error) => console.error(error));

--- a/src/context.js
+++ b/src/context.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Context = React.createContext();
+
+export default Context;


### PR DESCRIPTION
I'd read about using "Context" for state management... I think? There was a lot of directly passing props down to different components, and it seemed several of them held props that had nothing to do with that component, but rather a child. It seemed like a of extra words and convoluted interfaces. SO I looked into trying useContext. I am not positive I implemented it correctly, but I think I would have been able to build this with less errors if I'd gone this route. Though I am still trying to fully understand the pros and cons of this route vs how I did it explicitly passing props. The way I initially did it made it easy to visually track which components were using what, but useContext is just faster and easier on my mind. Though it is a small application - I imagine the differences would shine through a lot brighter in a large app!